### PR TITLE
feat(main-ui): add new buttons and tracing integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dioxus-popup = { path = "deps/rust-sdk/packages/dioxus-popup" }
 dioxus-aws = { path = "deps/rust-sdk/packages/dioxus-aws" }
 google-wallet = { path = "deps/rust-sdk/packages/google-wallet" }
 dioxus-translate = { path = "deps/rust-sdk/packages/dioxus-translate", features = ["ko"] }
+btracing = { path = "deps/rust-sdk/packages/btracing" }
 rest-api = { path = "deps/rust-sdk/packages/rest-api" }
 by-macros = { path = "deps/rust-sdk/packages/by-macros" }
 by-axum = { path = "deps/rust-sdk/packages/by-axum" }

--- a/packages/main-ui/Cargo.toml
+++ b/packages/main-ui/Cargo.toml
@@ -26,7 +26,7 @@ tracing = { version = "0.1.40" }
 
 wasm-bindgen = { version = "0.2.100" }
 wasm-bindgen-futures = { version = "0.4.50" }
-web-sys = { version = "0.3.72", features=["Navigator"]}
+web-sys = { version = "0.3.72", features=["Navigator","Clipboard"]}
 serde = "1.0.216"
 num-format = "0.4.4"
 serde-wasm-bindgen = "0.6.5"
@@ -49,6 +49,8 @@ mime_guess = "2.0.5"
 validator.workspace = true
 by-types.workspace = true
 async-trait = "0.1.86"
+dioxus-toast = { version = "0.6.0", default-features = false, features = ["web"] }
+btracing.workspace = true
 
 [features]
 default = []

--- a/packages/main-ui/Makefile
+++ b/packages/main-ui/Makefile
@@ -52,13 +52,13 @@ serve: clean public/tailwind.css
 	$(BUILD_ENV) dx serve --addr 0.0.0.0 --platform web  --client-features web-only
 
 run: clean node_modules public
-	$(BUILD_ENV) dx serve --fullstack
+	$(BUILD_ENV) dx serve --fullstack --platform web
 
 node_modules:
 	npm i
 
 build: clean public
-	$(BUILD_ENV) dx build --release --fullstack --server-features lambda
+	$(BUILD_ENV) dx build --release --fullstack --server-features lambda  --platform web
 	cp -r $(WORKSPACE_ROOT)/target/dx/$(SERVICE)/release/web $(ARTIFACT_DIR)
 	mv $(ARTIFACT_DIR)/server $(ARTIFACT_DIR)/bootstrap
 

--- a/packages/main-ui/src/components/buttons.rs
+++ b/packages/main-ui/src/components/buttons.rs
@@ -1,0 +1,61 @@
+#![allow(non_snake_case)]
+use dioxus::prelude::*;
+
+use crate::components::icons::{heart::HeartIcon, send::SendIcon};
+
+#[component]
+pub fn HoverPrimaryButton(
+    children: Element,
+    onchangehover: EventHandler<bool>,
+    onclick: EventHandler<()>,
+) -> Element {
+    rsx! {
+        button {
+            class: "flex flex-row items-center justify-center gap-[10px] hover:bg-[#D4EED4] px-[10px] py-[4] rounded-[12px] text-[#5B5B5B] hover:text-[#16775D] font-semibold",
+            onmouseenter: move |_| onchangehover(true),
+            onmouseleave: move |_| onchangehover(false),
+            onclick: move |_| {
+                onclick(());
+            },
+            {children}
+        }
+    }
+}
+
+#[component]
+pub fn ShareButton(onclick: EventHandler<()>) -> Element {
+    let mut hover = use_signal(|| false);
+    let color = if hover() { "#16775D" } else { "#979797" };
+
+    rsx! {
+        HoverPrimaryButton {
+            onclick: move |_| {
+                onclick(());
+            },
+            onchangehover: move |e| {
+                hover.set(e);
+            },
+            SendIcon { color: "{color}" }
+            "Share"
+        }
+    }
+}
+
+#[component]
+pub fn HeartButton(onclick: EventHandler<()>, liked: bool, children: Element) -> Element {
+    let mut hover = use_signal(|| false);
+    let color = if hover() { "#16775D" } else { "#979797" };
+
+    rsx! {
+        HoverPrimaryButton {
+            onclick: move |_| {
+                onclick(());
+            },
+            onchangehover: move |e| {
+                hover.set(e);
+            },
+            HeartIcon { color: "{color}", fill: if liked { "{color}" } else { "none" } }
+            {children}
+        }
+    }
+}

--- a/packages/main-ui/src/components/icons/heart.rs
+++ b/packages/main-ui/src/components/icons/heart.rs
@@ -1,6 +1,10 @@
 use dioxus::prelude::*;
 
-pub fn HeartIcon() -> Element {
+#[component]
+pub fn HeartIcon(
+    #[props(default = "#979797".to_string())] color: String,
+    #[props(default = "none".to_string())] fill: String,
+) -> Element {
     rsx! {
         svg {
             width: "24",
@@ -10,7 +14,8 @@ pub fn HeartIcon() -> Element {
             xmlns: "http://www.w3.org/2000/svg",
             path {
                 d: "M4.42602 13.2841L12 20.8581L19.574 13.2841C21.4753 11.3828 21.4753 8.30004 19.574 6.39868C17.6726 4.49732 14.5899 4.49732 12.6885 6.39868L12 7.08722L11.3115 6.39868C9.4101 4.49732 6.32738 4.49732 4.42602 6.39868C2.52466 8.30004 2.52466 11.3828 4.42602 13.2841Z",
-                stroke: "#979797",
+                fill: "{fill}",
+                stroke: "{color}",
                 stroke_width: "1.5",
                 stroke_linejoin: "round",
             }

--- a/packages/main-ui/src/components/icons/send.rs
+++ b/packages/main-ui/src/components/icons/send.rs
@@ -1,6 +1,7 @@
 use dioxus::prelude::*;
 
-pub fn SendIcon() -> Element {
+#[component]
+pub fn SendIcon(#[props(default = "#979797".to_string())] color: String) -> Element {
     rsx! {
         svg {
             width: "19",
@@ -11,14 +12,14 @@ pub fn SendIcon() -> Element {
             g {
                 path {
                     d: "M4.80467 4.75522L12.843 2.07578C16.4503 0.873345 18.4102 2.84269 17.2172 6.45L14.5378 14.4883C12.7389 19.8945 9.78485 19.8945 7.98593 14.4883L7.19061 12.1024L4.80467 11.3071C-0.601557 9.50813 -0.601557 6.56361 4.80467 4.75522Z",
-                    stroke: "#979797",
+                    stroke: "{color}",
                     stroke_width: "1.5",
                     stroke_linecap: "round",
                     stroke_linejoin: "round",
                 }
                 path {
                     d: "M7.37109 11.692L10.7606 8.29297",
-                    stroke: "#979797",
+                    stroke: "{color}",
                     stroke_width: "1.5",
                     stroke_linecap: "round",
                     stroke_linejoin: "round",

--- a/packages/main-ui/src/components/mod.rs
+++ b/packages/main-ui/src/components/mod.rs
@@ -1,2 +1,3 @@
+pub mod buttons;
 pub mod headings;
 pub mod icons;

--- a/packages/main-ui/src/main.rs
+++ b/packages/main-ui/src/main.rs
@@ -24,6 +24,10 @@ fn main() {
 }
 
 fn app() -> Element {
+    std::panic::set_hook(Box::new(|info| {
+        tracing::error!("Panic: {}", info);
+    }));
+
     use_context_provider(|| ColorTheme {
         background: "#E9F2EC",
         card: CardColorTheme {
@@ -44,6 +48,8 @@ fn app() -> Element {
     PopupService::init();
 
     rsx! {
+        btracing::ToastTracing {}
+
         document::Meta {
             name: "viewport",
             content: "width=device-width, initial-scale=1.0",

--- a/packages/main-ui/src/pages/contents/_id/page.rs
+++ b/packages/main-ui/src/pages/contents/_id/page.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
-use crate::components::icons::heart::HeartIcon;
-use crate::components::icons::send::SendIcon;
+use crate::components::buttons::HeartButton;
+use crate::components::buttons::ShareButton;
 use crate::pages::ColGridCards;
 
 use super::controller::*;
@@ -99,18 +99,18 @@ pub fn NftDescription(
 
                 div { class: "flex flex-row justify-start items-center gap-[10px] text-[#5B5B5B]",
                     //like
-                    button {
-                        class: "flex flex-row items-center justify-center gap-[10px] hover:bg-gray-200 px-[20px] py-[10px] rounded-[12px]",
+                    HeartButton {
                         onclick: move |_| async move {
                             ctrl.handle_like().await;
                         },
-                        HeartIcon {}
+                        liked: content.liked,
                         "{content.likes}"
                     }
                     //share
-                    button { class: "flex flex-row items-center justify-center gap-[10px] hover:bg-gray-200 px-[20px] py-[10px] rounded-[12px]",
-                        SendIcon {}
-                        "Share"
+                    ShareButton {
+                        onclick: move |_| async move {
+                            ctrl.handle_share().await;
+                        },
                     }
                     a {
                         class: " hover:bg-gray-200 px-[20px] py-[10px] rounded-[12px] flex flex-row items-center justify-center gap-[10px]",


### PR DESCRIPTION
+ Added `HoverPrimaryButton`, `ShareButton`, and `HeartButton` components.
+ Integrated `btracing` and `dioxus-toast` for enhanced tracing and toast notifications.
+ Updated `HeartIcon` and `SendIcon` components to accept color and fill properties.
+ Modified `Makefile` to include `--platform web` in build and run commands.
+ Enhanced clipboard sharing functionality in `Controller` with `handle_share` method.