### PR TITLE
fix svg image bugfix

### DIFF
--- a/packages/main-ui/src/pages/contents/new/page.rs
+++ b/packages/main-ui/src/pages/contents/new/page.rs
@@ -144,7 +144,7 @@ pub fn SingleContent(
                         onchange: move |hover| dropping.set(hover),
                         if let Some(image) = thumbnail() {
                             img {
-                                class: "w-full object-cover rounded-[12px]",
+                                class: "w-full max-w-[200px] object-cover rounded-[12px]",
                                 src: image,
                             }
                         } else {


### PR DESCRIPTION
https://github.com/biyard/incheon-heroes/issues/97
https://github.com/biyard/incheon-heroes/issues/88

- Since it appears to be the same issue, we handle it together.
- The infer package appears to be unable to parse svg images properly, so manual logic was implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced file upload handling now accurately detects SVG images and assigns the correct content type, ensuring smoother file processing.
- **Style**
  - Updated the display of images with a maximum width constraint to improve visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->