### PR TITLE
Fix: Mobile - NFT share button not working

### DIFF
--- a/packages/main-ui/src/pages/contents/_id/controller.rs
+++ b/packages/main-ui/src/pages/contents/_id/controller.rs
@@ -59,7 +59,7 @@ impl Controller {
     }
 
     pub async fn handle_share(&self) {
-        let _ = wasm_bindgen_futures::JsFuture::from(
+        let result = wasm_bindgen_futures::JsFuture::from(
             web_sys::window()
                 .unwrap()
                 .navigator()
@@ -68,7 +68,14 @@ impl Controller {
         )
         .await;
 
-        btracing::info!("Copied sharing URL");
+        match result {
+            Ok(_) => {
+                btracing::info!("Copied sharing URL: {}", self.path());
+            }
+            Err(e) => {
+                btracing::error!("Failed to copy sharing URL: {:?}", e);
+            }
+        }
     }
 
     pub fn opensea_url(&self) -> String {

--- a/packages/main-ui/src/pages/contents/_id/page.rs
+++ b/packages/main-ui/src/pages/contents/_id/page.rs
@@ -121,6 +121,7 @@ pub fn NftDescription(
                     //share
                     ShareButton {
                         onclick: move |_| async move {
+                            btracing::info!("Share button clicked!");
                             ctrl.handle_share().await;
                         },
                     }


### PR DESCRIPTION
As opened in #113
The share button seems to not be working.

Currently, I don't see anything wrong in the code yet so I just added error handling and logging to handle_share

But ideally, we need to verify that the Clipboard API is supported and works on the target mobile browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the share functionality to provide clearer feedback on clipboard operations, ensuring that both successful and failed sharing attempts are better tracked.
  - Added a log message when the share button is clicked to improve overall feedback and monitoring without altering the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->