### PR TITLE
Handle account change on kaia wallet

### DIFF
--- a/packages/dto/src/contracts/mod.rs
+++ b/packages/dto/src/contracts/mod.rs
@@ -1,3 +1,4 @@
 pub mod common_contract;
 pub mod incheon_contents;
 pub mod klaytn_transaction;
+pub mod kaikas_browser;

--- a/packages/dto/src/contracts/mod.rs
+++ b/packages/dto/src/contracts/mod.rs
@@ -1,4 +1,3 @@
 pub mod common_contract;
 pub mod incheon_contents;
 pub mod klaytn_transaction;
-pub mod kaikas_browser;

--- a/packages/dto/src/wallets/kaikas_wallet.rs
+++ b/packages/dto/src/wallets/kaikas_wallet.rs
@@ -59,15 +59,6 @@ impl KaikasWallet {
 
         tracing::debug!("selected address: {address}");
 
-         // Listen for account changes
-         let k_clone = k.clone();
-         let callback = Closure::wrap(Box::new(move |accounts: JsValue| {
-             let accounts: Vec<String> = serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
-             if let Some(new_address) = accounts.get(0) {
-                 tracing::debug!("Account changed to: {new_address}");
-             }
-         }) as Box<dyn FnMut(JsValue)>);
-
         Ok(Self {
             address,
             chain_id: chain_id.as_u64(),

--- a/packages/dto/src/wallets/kaikas_wallet.rs
+++ b/packages/dto/src/wallets/kaikas_wallet.rs
@@ -59,6 +59,15 @@ impl KaikasWallet {
 
         tracing::debug!("selected address: {address}");
 
+         // Listen for account changes
+         let k_clone = k.clone();
+         let callback = Closure::wrap(Box::new(move |accounts: JsValue| {
+             let accounts: Vec<String> = serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
+             if let Some(new_address) = accounts.get(0) {
+                 tracing::debug!("Account changed to: {new_address}");
+             }
+         }) as Box<dyn FnMut(JsValue)>);
+
         Ok(Self {
             address,
             chain_id: chain_id.as_u64(),

--- a/packages/dto/src/wallets/kaikas_wallet.rs
+++ b/packages/dto/src/wallets/kaikas_wallet.rs
@@ -7,6 +7,7 @@ use ethers::{
 };
 
 use crate::contracts::klaytn_transaction::KlaytnTransaction;
+use wasm_bindgen::prelude::*;
 
 use super::KaiaWallet;
 use crate::Result;
@@ -58,6 +59,31 @@ impl KaikasWallet {
         Self::switch_chain(chain_id.as_u64()).await?;
 
         tracing::debug!("selected address: {address}");
+
+        // Add event listener for account changes
+        let user_service = use_context::<UserService>();
+        let on_accounts_changed = Closure::wrap(Box::new(move |accounts: JsValue| {
+            let accounts: Vec<String> =
+                serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
+            if let Some(new_address) = accounts.get(0) {
+                tracing::debug!("Account changed to: {}", new_address);
+                // Update the UserService with the new address
+                spawn(async move {
+                    let mut user_service = user_service.clone();
+                    user_service
+                        .update_wallet_address(new_address.clone())
+                        .await;
+                });
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        k.on(
+            "accountsChanged",
+            on_accounts_changed.as_ref().unchecked_ref(),
+        )
+        .await;
+
+        on_accounts_changed.forget();
 
         Ok(Self {
             address,

--- a/packages/dto/src/wallets/mod.rs
+++ b/packages/dto/src/wallets/mod.rs
@@ -4,6 +4,7 @@ pub mod kaikas_wallet;
 pub mod local_fee_payer;
 pub mod remote_fee_payer;
 pub mod wallet;
+pub mod kaikas_browser;
 
 use async_trait::async_trait;
 use ethers::types::{Signature, H160};

--- a/packages/dto/src/wallets/mod.rs
+++ b/packages/dto/src/wallets/mod.rs
@@ -4,7 +4,6 @@ pub mod kaikas_wallet;
 pub mod local_fee_payer;
 pub mod remote_fee_payer;
 pub mod wallet;
-pub mod kaikas_browser;
 
 use async_trait::async_trait;
 use ethers::types::{Signature, H160};

--- a/packages/main-ui/src/pages/connect/controller.rs
+++ b/packages/main-ui/src/pages/connect/controller.rs
@@ -4,7 +4,6 @@ use dioxus_oauth::prelude::FirebaseService;
 use dioxus_translate::Language;
 use dto::User;
 use google_wallet::drive_api::DriveApi;
-use wasm_bindgen::JsValue;
 
 use crate::{
     config,
@@ -47,7 +46,7 @@ impl Controller {
         let cred = self
             .firebase
             .sign_in_with_popup(vec![
-                "https://www.googleapis.com/auth/drive.appdata".to_string(),
+                "https://www.googleapis.com/auth/drive.appdata".to_string()
             ])
             .await;
 
@@ -251,24 +250,6 @@ impl Controller {
             }
         };
 
-        // Listen for account changes
-        let user_service = self.user.clone();
-        let callback = wasm_bindgen::prelude::Closure::wrap(Box::new(move |accounts: JsValue| {
-            let accounts: Vec<String> =
-                serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
-            if let Some(new_address) = accounts.get(0) {
-                spawn(async move {
-                    user_service
-                        .handle_account_change(new_address.clone())
-                        .await;
-                });
-            }
-        }) as Box<dyn FnMut(JsValue)>);
-
-        let k = dto::wallets::kaikas_browser::klaytn().unwrap();
-        k.on("accountsChanged", callback.as_ref().unchecked_ref());
-        callback.forget();
-
         if self.nav.can_go_back() {
             self.nav.go_back();
         } else {
@@ -276,5 +257,6 @@ impl Controller {
             self.nav.replace(Route::HomePage { lang: self.lang });
         }
     }
+
     pub async fn handle_internet_identity(&self) {}
 }

--- a/packages/main-ui/src/pages/connect/controller.rs
+++ b/packages/main-ui/src/pages/connect/controller.rs
@@ -282,6 +282,7 @@ impl Controller {
 
             on_accounts_changed.forget();
         });
+        
     }
 
     pub async fn handle_internet_identity(&self) {}

--- a/packages/main-ui/src/pages/connect/controller.rs
+++ b/packages/main-ui/src/pages/connect/controller.rs
@@ -3,6 +3,7 @@ use dioxus::prelude::*;
 use dioxus_oauth::prelude::FirebaseService;
 use dioxus_translate::Language;
 use dto::User;
+use dto::wallets::kaikas_browser::klaytn;
 use google_wallet::drive_api::DriveApi;
 use wasm_bindgen::prelude::*;
 
@@ -261,7 +262,7 @@ impl Controller {
         // Listen for account changes and update the UserService
         let user_service = self.user.clone();
         spawn(async move {
-            let k = klaytn().unwrap();
+            let k = klaytn();
             let on_accounts_changed = Closure::wrap(Box::new(move |accounts: JsValue| {
                 let accounts: Vec<String> =
                     serde_wasm_bindgen::from_value(accounts).unwrap_or_default();

--- a/packages/main-ui/src/pages/connect/controller.rs
+++ b/packages/main-ui/src/pages/connect/controller.rs
@@ -4,6 +4,7 @@ use dioxus_oauth::prelude::FirebaseService;
 use dioxus_translate::Language;
 use dto::User;
 use google_wallet::drive_api::DriveApi;
+use wasm_bindgen::JsValue;
 
 use crate::{
     config,
@@ -46,7 +47,7 @@ impl Controller {
         let cred = self
             .firebase
             .sign_in_with_popup(vec![
-                "https://www.googleapis.com/auth/drive.appdata".to_string()
+                "https://www.googleapis.com/auth/drive.appdata".to_string(),
             ])
             .await;
 
@@ -250,6 +251,24 @@ impl Controller {
             }
         };
 
+        // Listen for account changes
+        let user_service = self.user.clone();
+        let callback = Closure::wrap(Box::new(move |accounts: JsValue| {
+            let accounts: Vec<String> =
+                serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
+            if let Some(new_address) = accounts.get(0) {
+                spawn(async move {
+                    user_service
+                        .handle_account_change(new_address.clone())
+                        .await;
+                });
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let k = klaytn().unwrap();
+        k.on("accountsChanged", callback.as_ref().unchecked_ref());
+        callback.forget();
+
         if self.nav.can_go_back() {
             self.nav.go_back();
         } else {
@@ -257,6 +276,5 @@ impl Controller {
             self.nav.replace(Route::HomePage { lang: self.lang });
         }
     }
-
     pub async fn handle_internet_identity(&self) {}
 }

--- a/packages/main-ui/src/pages/connect/controller.rs
+++ b/packages/main-ui/src/pages/connect/controller.rs
@@ -253,7 +253,7 @@ impl Controller {
 
         // Listen for account changes
         let user_service = self.user.clone();
-        let callback = Closure::wrap(Box::new(move |accounts: JsValue| {
+        let callback = wasm_bindgen::prelude::Closure::wrap(Box::new(move |accounts: JsValue| {
             let accounts: Vec<String> =
                 serde_wasm_bindgen::from_value(accounts).unwrap_or_default();
             if let Some(new_address) = accounts.get(0) {
@@ -265,7 +265,7 @@ impl Controller {
             }
         }) as Box<dyn FnMut(JsValue)>);
 
-        let k = klaytn().unwrap();
+        let k = dto::wallets::kaikas_browser::klaytn().unwrap();
         k.on("accountsChanged", callback.as_ref().unchecked_ref());
         callback.forget();
 

--- a/packages/main-ui/src/services/user_service.rs
+++ b/packages/main-ui/src/services/user_service.rs
@@ -327,6 +327,18 @@ impl UserService {
     pub fn icp_address(&self) -> Option<String> {
         self.wallet().principal()
     }
+
+    pub async fn update_wallet_address(&mut self, new_address: String) {
+        match self.wallet() {
+            UserWallet::KaiaWallet(ref mut kaia_wallet) => {
+                kaia_wallet.address = new_address;
+                self.set_wallet(self.wallet()).await;
+            }
+            _ => {
+                tracing::warn!("Cannot update wallet address: Wallet is not a KaiaWallet");
+            }
+        }
+    }
 }
 
 #[cfg_attr(not(feature = "server"), async_trait(?Send))]

--- a/packages/main-ui/src/services/user_service.rs
+++ b/packages/main-ui/src/services/user_service.rs
@@ -327,33 +327,6 @@ impl UserService {
     pub fn icp_address(&self) -> Option<String> {
         self.wallet().principal()
     }
-
-    pub async fn handle_account_change(&mut self, new_address: String) {
-        // Update the wallet with the new address
-        let wallet = match self.wallet() {
-            UserWallet::KaiaWallet(mut wallet) => {
-                wallet.address = new_address.clone();
-                UserWallet::KaiaWallet(wallet)
-            }
-            _ => return,
-        };
-
-        self.set_wallet(wallet).await;
-
-        // Re-fetch user data with the new address
-        let endpoint = config::get().new_api_endpoint;
-        match User::get_client(endpoint)
-            .get_user_by_address(new_address)
-            .await
-        {
-            Ok(user) => {
-                self.user.set(Some(user));
-            }
-            Err(e) => {
-                tracing::error!("Failed to get user by address: {e}");
-            }
-        }
-    }
 }
 
 #[cfg_attr(not(feature = "server"), async_trait(?Send))]

--- a/packages/main-ui/src/services/user_service.rs
+++ b/packages/main-ui/src/services/user_service.rs
@@ -327,6 +327,33 @@ impl UserService {
     pub fn icp_address(&self) -> Option<String> {
         self.wallet().principal()
     }
+
+    pub async fn handle_account_change(&mut self, new_address: String) {
+        // Update the wallet with the new address
+        let wallet = match self.wallet() {
+            UserWallet::KaiaWallet(mut wallet) => {
+                wallet.address = new_address.clone();
+                UserWallet::KaiaWallet(wallet)
+            }
+            _ => return,
+        };
+
+        self.set_wallet(wallet).await;
+
+        // Re-fetch user data with the new address
+        let endpoint = config::get().new_api_endpoint;
+        match User::get_client(endpoint)
+            .get_user_by_address(new_address)
+            .await
+        {
+            Ok(user) => {
+                self.user.set(Some(user));
+            }
+            Err(e) => {
+                tracing::error!("Failed to get user by address: {e}");
+            }
+        }
+    }
 }
 
 #[cfg_attr(not(feature = "server"), async_trait(?Send))]


### PR DESCRIPTION
Attempts to resolve #141

- Listen for Account Changes: Modify KaikasWallet to listen for account changes using the on method.

- Update User Profile: Implement handle_account_change in UserService to update the user's profile when an account change is detected.

- Integrate in Controller: Integrate the account change handling in the controller to call handle_account_change when an account change is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced wallet account management: The application now automatically listens for and adapts to wallet account changes, ensuring seamless updates to your account and related data.
  - Introduced improved browser wallet connectivity with the addition of a new module for better integration.
  - New functionality to update wallet addresses specifically for KaiaWallet users.

- **Chores**
  - Upgraded a core dependency to deliver improved performance and stability.
  
- **Style**
  - Minor formatting updates made for consistency in the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->