### PR TITLE
Add informational message to source file upload screen

### DIFF
--- a/packages/main-ui/src/pages/contents/new/i18n.rs
+++ b/packages/main-ui/src/pages/contents/new/i18n.rs
@@ -44,8 +44,8 @@ translate! {
     },
 
     placeholder_source: {
-        ko: "원본 파일(SVG, AI 등)을 업로드하세요",
-        en: "Upload the source file like SVG, AI, etc.",
+        ko: "원본 파일(SVG, AI 등)을 업로드하세요.\n\n원본 파일이 제공되지 않을 경우, 썸네일 이미지가 원본 파일로 자동 대체됩니다. 다만, 썸네일 이미지는 해상도 및 품질이 제한될 수 있으므로, 원본 파일을 추가로 제공하는 것을 권장합니다.",
+        en: "Upload the source file like SVG, AI, etc.\n\nIf the original file is not provided, the thumbnail image will automatically be used as the original file. However, since the thumbnail image may have limitations in resolution and quality, it is recommended to additionally provide the original file.",
     },
 
     placeholder_title: {
@@ -82,9 +82,4 @@ translate! {
         ko: "취소",
         en: "Cancel",
     },
-
-    info_source_upload: {
-        ko: "원본 파일이 제공되지 않을 경우, 썸네일 이미지가 원본 파일로 자동 대체됩니다. 다만, 썸네일 이미지는 해상도 및 품질이 제한될 수 있으므로, 원본 파일을 추가로 제공하는 것을 권장합니다.",
-        en: "If the original file is not provided, the thumbnail image will automatically be used as the original file. However, since the thumbnail image may have limitations in resolution and quality, it is recommended to additionally provide the original file.",
-    }
 }

--- a/packages/main-ui/src/pages/contents/new/i18n.rs
+++ b/packages/main-ui/src/pages/contents/new/i18n.rs
@@ -82,4 +82,9 @@ translate! {
         ko: "취소",
         en: "Cancel",
     },
+
+    info_source_upload: {
+        ko: "원본 파일이 제공되지 않을 경우, 썸네일 이미지가 원본 파일로 자동 대체됩니다. 다만, 썸네일 이미지는 해상도 및 품질이 제한될 수 있으므로, 원본 파일을 추가로 제공하는 것을 권장합니다.",
+        en: "If the original file is not provided, the thumbnail image will automatically be used as the original file. However, since the thumbnail image may have limitations in resolution and quality, it is recommended to additionally provide the original file.",
+    }
 }

--- a/packages/main-ui/src/pages/contents/new/page.rs
+++ b/packages/main-ui/src/pages/contents/new/page.rs
@@ -212,10 +212,6 @@ pub fn SingleContent(
                         }
                     }
                 }
-
-                p { class: "text-[12px] text-[#8d8d8d]",
-                    "{tr.info_source_upload}"
-                }
             }
 
             InputWithLabel {

--- a/packages/main-ui/src/pages/contents/new/page.rs
+++ b/packages/main-ui/src/pages/contents/new/page.rs
@@ -212,6 +212,10 @@ pub fn SingleContent(
                         }
                     }
                 }
+
+                p { class: "text-[12px] text-[#8d8d8d]",
+                    "{tr.info_source_upload}"
+                }
             }
 
             InputWithLabel {


### PR DESCRIPTION
related to #148

`Implementation Suggestion`
![419021923-9e805359-49dd-4fc4-a787-b6349ec1e601](https://github.com/user-attachments/assets/1beee4f4-f0f3-457f-bb45-3ce2733d981e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the file upload guidance to inform users that if an original file isn’t provided, a thumbnail image will be used automatically.
  - Added a note about potential resolution and quality limitations of thumbnails, recommending that original files be provided for optimal results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->