### PR TITLE
Fix share button error

### DIFF
--- a/packages/main-ui/src/pages/contents/_id/controller.rs
+++ b/packages/main-ui/src/pages/contents/_id/controller.rs
@@ -78,10 +78,10 @@ impl Controller {
 
         match result {
             Ok(_) => {
-                btracing::info!("Copied sharing URL: {}", self.path());
+                btracing::info!("Copied sharing URL: {}", full_url);
             }
             Err(e) => {
-                btracing::error!("Failed to copy sharing URL: {:?}", e);
+                btracing::error!("Failed to copy full URL: {:?}", e);
             }
         }
     }

--- a/packages/main-ui/src/pages/contents/_id/controller.rs
+++ b/packages/main-ui/src/pages/contents/_id/controller.rs
@@ -59,12 +59,20 @@ impl Controller {
     }
 
     pub async fn handle_share(&self) {
+        let origin = web_sys::window()
+            .unwrap()
+            .location()
+            .origin()
+            .unwrap_or_else(|_| String::new());
+
+        let full_url = format!("{}{}", origin, self.path());
+
         let result = wasm_bindgen_futures::JsFuture::from(
             web_sys::window()
                 .unwrap()
                 .navigator()
                 .clipboard()
-                .write_text(&self.path()),
+                .write_text(&full_url),
         )
         .await;
 


### PR DESCRIPTION
Related to #170


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved sharing functionality: When you share a link, the system now copies the complete URL—including both the domain and the path—to your clipboard. This ensures that the links you share reliably direct recipients to the intended page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->