### PR TITLE
Integrate SIWE into the Kaia wallet login flow

### DIFF
--- a/packages/dto/src/wallets/kaikas_wallet.rs
+++ b/packages/dto/src/wallets/kaikas_wallet.rs
@@ -25,6 +25,9 @@ use wasm_bindgen_futures::JsFuture;
 #[cfg(feature = "web")]
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "web")]
+use ethers::types::U256;
+
 #[cfg(not(feature = "web"))]
 impl KaikasWallet {
     pub async fn new(_provider: Arc<Provider<Http>>) -> Result<Self> {

--- a/packages/main-ui/Cargo.toml
+++ b/packages/main-ui/Cargo.toml
@@ -30,6 +30,9 @@ web-sys = { version = "0.3.72", features=["Navigator","Clipboard"]}
 serde = "1.0.216"
 num-format = "0.4.4"
 serde-wasm-bindgen = "0.6.5"
+serde_bytes = "0.11"
+rand = "0.9.0"
+ic_siwe = {version = "0.0.6", git="https://github.com/hackartists/ic-siwe.git", branch="main" }
 
 chrono = "0.4.39"
 base64 = "0.22.1"

--- a/packages/main-ui/src/services/icp_canister.rs
+++ b/packages/main-ui/src/services/icp_canister.rs
@@ -3,11 +3,13 @@
 use by_macros::DioxusController;
 use dioxus::prelude::*;
 
-use candid::{encode_args, utils::ArgumentEncoder, CandidType, Decode, Principal};
+use candid::{CandidType, Decode, Principal, encode_args, utils::ArgumentEncoder};
 use dto::*;
 use ic_agent::Agent;
+use ic_siwe::login::LoginDetails;
 use nft::Nft;
 use serde::Deserialize;
+use serde_bytes::ByteBuf;
 
 use crate::config;
 
@@ -85,5 +87,15 @@ impl IcpCanister {
         let inter_output = Box::leak(Box::new(inter_output));
 
         candid::Decode!(inter_output, R).map_err(|e| Error::CandidError(e.to_string()))
+    }
+
+    pub async fn siwe_login(
+        &self,
+        signature: String,
+        address: String,
+        session_key: ByteBuf,
+    ) -> Result<LoginDetails> {
+        self.update("siwe_login", (signature, address, session_key))
+            .await
     }
 }

--- a/packages/main-ui/src/services/user_service.rs
+++ b/packages/main-ui/src/services/user_service.rs
@@ -371,11 +371,6 @@ impl UserService {
             }
         }
     }
-
-    // pub async fn set_icp_wallet(&mut self, wallet: Option<Arc<BasicIdentity>>) {
-    //     self.icp_wallet.set(wallet);
-    // }
-
 }
 
 #[cfg_attr(not(feature = "server"), async_trait(?Send))]

--- a/packages/main-ui/src/services/user_service.rs
+++ b/packages/main-ui/src/services/user_service.rs
@@ -371,6 +371,11 @@ impl UserService {
             }
         }
     }
+
+    // pub async fn set_icp_wallet(&mut self, wallet: Option<Arc<BasicIdentity>>) {
+    //     self.icp_wallet.set(wallet);
+    // }
+
 }
 
 #[cfg_attr(not(feature = "server"), async_trait(?Send))]


### PR DESCRIPTION
Related to #158

Still implementing.

Implementation so far:

Modified handle_kaia Method:
- Added SIWE (Sign-In With Ethereum) message generation and signing.
- Integrated a call to the ICP canister's siwe_login method for user authentication using SIWE.
- Updated the user's wallet and session state upon a successful login.

Added siwe_login Method:
- Implements a method to call the ICP canister's siwe_login endpoint for authenticating users via SIWE.

Added sign_message Method:
- Web Environment: Utilizes Kaikas Wallet's klay_sign method to sign the SIWE message.
- Non-Web Environment: Returns an error, as signing is not supported in non-web environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Web wallet now supports message signing for enhanced digital signature operations.
  - User authentication has been improved with a secure, SIWE-based sign-in flow that incorporates session key generation and robust error handling.

- **Chores**
  - Updated project dependencies to integrate libraries for advanced byte handling, randomization, and SIWE authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->