### PR TITLE
fix mobile overflow bugfix

### DIFF
--- a/packages/main-ui/src/pages/page.rs
+++ b/packages/main-ui/src/pages/page.rs
@@ -38,7 +38,7 @@ pub fn HomePage(lang: Language) -> Element {
                     .open(rsx! {
                         div { class: "flex flex-col max-w-[500px] max-[400px]:w-full justify-start items-start px-10 gap-[10px] pb-10",
                             div {
-                                class: "popup-content w-full",
+                                class: "popup-content w-full h-fit max-[500px]:h-[250px] max-[500px]:overflow-y-scroll",
                                 dangerous_inner_html: "{html_to_use}",
                             }
 


### PR DESCRIPTION
- mobile 내 modal overflow 시 의도치 않게 화면 내 꽉 찬 모달이 나오는 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved popup content styling for better display and scrolling on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->